### PR TITLE
Get Target From AE Weight

### DIFF
--- a/backend/datasets/parse_datasets.py
+++ b/backend/datasets/parse_datasets.py
@@ -3,7 +3,6 @@ import time
 import pyarrow.parquet as pq
 from neomodel import config, db
 from neo4j import GraphDatabase
-from graphdatascience import GraphDataScience
 
 """
 Open Targets Neo4j Importer

--- a/backend/search/urls.py
+++ b/backend/search/urls.py
@@ -73,7 +73,7 @@ urlpatterns = [
 
     # This route returns an array of adverse events associated with a specific target, optionally filtered by action types. It requires the drug target symbol as a path parameter
     # target: Drug Symbol
-    path('api/weight/<str:target>/', GetAdverseEventByTargetView.as_view(), name='get_adverse_event'),
+    path('api/weight/<str:target>/', GetAdverseEventByTargetView.as_view(), name='get_adverse_event_weights_from_ae'),
 
     # This route returns an array of weights (log likelihood ratios) of adverse events associated with a specific target. It requires the drug target symbol and adverse event ID (meddraId) as path parameters.
     # target: Drug Symbol, ae: meddraId
@@ -81,11 +81,11 @@ urlpatterns = [
 
     # This route returns an array of targets associated with a specific adverse event, optionally filtered by action types. It requires the meddraId as a path parameter
     # target: ae: meddraId
-    path('api/ae-weight/<str:ae>/', GetTargetByAdverseEventView.as_view(), name='get_adverse_event'),
+    path('api/ae-weight/<str:ae>/', GetTargetByAdverseEventView.as_view(), name='get_target_weights_from_ae'),
 
     # This route returns an array of weights (log likelihood ratios) of and adverse events association for several targets. It requires the adverse event ID (meddraId) and drug target symbol as path parameters.
     # target: Drug Symbol, ae: meddraId
-    path('api/ae-weight/<str:ae>/<str:target>/', GetTargetByAdverseEventView.as_view(), name='get_weights_target_ae'),
+    path('api/ae-weight/<str:ae>/<str:target>/', GetTargetByAdverseEventView.as_view(), name='get_weights_ae_target'),
 
     # These paths define API routes for querying paths from a target to one or all adverse events
     # associated with it, optionally filtered by drug and action.

--- a/backend/search/urls.py
+++ b/backend/search/urls.py
@@ -11,6 +11,7 @@ from .views import (
     # GetReactome,
     # GetSignor,
     GetTargetAdverseEventPath,
+    GetTargetByAdverseEventView,
     RoutesListAPIView,
     CountView,
     GetAdverseEventByTargetView,
@@ -74,9 +75,17 @@ urlpatterns = [
     # target: Drug Symbol
     path('api/weight/<str:target>/', GetAdverseEventByTargetView.as_view(), name='get_adverse_event'),
 
-    # This route returns an array of weights (log likelihood ratios) of adverse events associated with a specific target, optionally filtered by action types. It requires the drug target symbol and adverse event ID (meddraId) as path parameters.
+    # This route returns an array of weights (log likelihood ratios) of adverse events associated with a specific target. It requires the drug target symbol and adverse event ID (meddraId) as path parameters.
     # target: Drug Symbol, ae: meddraId
     path('api/weight/<str:target>/<str:ae>/', GetAdverseEventByTargetView.as_view(), name='get_weights_target_ae'),
+
+    # This route returns an array of targets associated with a specific adverse event, optionally filtered by action types. It requires the meddraId as a path parameter
+    # target: ae: meddraId
+    path('api/ae-weight/<str:ae>/', GetTargetByAdverseEventView.as_view(), name='get_adverse_event'),
+
+    # This route returns an array of weights (log likelihood ratios) of and adverse events association for several targets. It requires the adverse event ID (meddraId) and drug target symbol as path parameters.
+    # target: Drug Symbol, ae: meddraId
+    path('api/ae-weight/<str:ae>/<str:target>/', GetTargetByAdverseEventView.as_view(), name='get_weights_target_ae'),
 
     # These paths define API routes for querying paths from a target to one or all adverse events
     # associated with it, optionally filtered by drug and action.

--- a/backend/search/utils.py
+++ b/backend/search/utils.py
@@ -222,6 +222,116 @@ def get_weights_by_target(target, adverse_event=None, action_types=None, drug=No
     # Return the list of formatted results
     return formatted_results
 
+def get_weights_by_ae(adverse_event, target=None, action_types=None, drug=None, count=None):
+    """
+    Retrieve a list of protein targets and their associated log likelihood ratios (llr) for a given adverse event.
+    Args:
+        adverse_event (str): The ID (meddraId) of the adverse event.
+        target (str, optional): The symbol of a specific protein target.
+        action_types (list, optional): A list of action types to filter the results by.
+        drug (str, optional): The ID of a specific drug to filter the results by.
+        count (int, optional): The maximum number of results to return.
+    Returns:
+        list: A list of formatted results containing either protein targets or drugs and their associated llr.
+    """
+
+    # Find active datasets and store them in the enabledSets variable.
+    enabled_datasets_query = "MATCH (nd:Dataset {enabled: true}) WITH COLLECT(nd.dataset) AS enabledSets"
+
+    # Construct the ASSOCIATED_WITH segment of the query to find drugs associated with the specified adverse event.
+    associated_query = f"""
+        MATCH (nae:AdverseEvent)-[raw:ASSOCIATED_WITH]-(nd:Drug)
+        WHERE nae.dataset IN enabledSets
+            AND raw.dataset IN enabledSets
+            AND nd.dataset IN enabledSets
+            AND nae.meddraId = '{adverse_event}'
+    """
+
+    # Filter the results based on the drug parameter, if provided.
+    if drug:
+        associated_query += f" AND nd.drug_id = '{drug}'"
+
+    # Collect the drugs that are associated with the specified adverse event and store them in the associatedDrugs variable.
+    associated_query += " WITH enabledSets, COLLECT(nd) AS associatedDrugs"
+
+    # Construct the TARGETS segment of the query to find targets associated with the associated drugs.
+    target_query = f"""
+        MATCH (nt:Target)-[rt:TARGETS]-(nd:Drug)-[raw:ASSOCIATED_WITH]-(nae:AdverseEvent)
+        WHERE nt.dataset IN enabledSets
+            AND rt.dataset IN enabledSets
+            AND nd.dataset IN enabledSets
+            AND raw.dataset IN enabledSets
+            AND nae.dataset IN enabledSets
+            AND nd in associatedDrugs
+            AND nae.meddraId = '{adverse_event}'
+    """
+
+
+    # Filter the results based on the target parameter, if provided.
+    if target:
+        target_query += f" AND toUpper(nt.symbol) = '{target.upper()}'"
+
+    # Filter the results based on the action_types parameter, if provided.
+    if action_types:
+        action_types_str = ", ".join(
+            [f"'{action_type}'" for action_type in action_types])
+        target_query += f" AND rt.actionType IN [{action_types_str}]"
+
+    # Define the return clause based on whether a target is provided.
+    # Calculate the sum of the llr values for each target or drug.
+    if target:
+        return_query = " RETURN nd, sum(toFloat(raw.llr))"
+    else:
+        return_query = " RETURN nt, sum(toFloat(raw.llr))"
+
+    # Sort the results by the summed llr values in descending order.
+    return_query += " ORDER BY sum(toFloat(raw.llr)) desc"
+
+    # Limit the number of results returned based on the count parameter, if provided.
+    if count:
+        return_query += f" LIMIT {count}"
+
+    # Combine all query segments to form the final Cypher query.
+    cypher_query = f"{enabled_datasets_query}{associated_query}{target_query}{return_query}"
+
+    # Run the Cypher query and retrieve the results.
+    results, _ = db.cypher_query(cypher_query)
+
+    # print(cypher_query)
+
+    # Format the results
+    formatted_results = []
+
+    # Loop through the results obtained from the Cypher query to format the data for output.
+    # Each entry in the results is a tuple with the first item being a node (either a drug or target)
+    # and the second item being the summed Log Likelihood Ratio (LLR) value.
+    for res in results:
+        # If a target parameter was provided, the output should include information on the drugs.
+        if target:
+            entry = {
+                "drugId": res[0]["chemblId"],  # The Chembl ID of the drug node.
+                "weight": res[1],             # The summed LLR value for the association.
+                "drugName": res[0]["drugId"]  # The internal drug ID of the drug node.
+            }
+        # If a target parameter was not provided, the output should include information on the protein targets.
+        else:
+            entry = {
+                "llr": res[1],                                 # The summed LLR value for the association.
+                "id": res[0]["symbol"],                        # The symbol of the protein target node.
+                "type": "Target",                              # The type of node (in this case, Target).
+                "symbol": res[0]["symbol"],                    # The symbol of the protein target node.
+                "name": res[0]["name"],                        # The name of the protein target node.
+                "dataset": res[0]["dataset"]                   # The dataset the target node belongs to.
+            }
+
+        # Append the formatted entry to the list of formatted results.
+        formatted_results.append(entry)
+
+    # Return the list of formatted results
+    return formatted_results
+
+
+
 def get_paths_target_ae_drug(target, action_types=None, adverse_event=None, drug=None, count=None):
     """
     This function finds paths between the given target, adverse events, and drugs. 


### PR DESCRIPTION
Added backend endpoints
api/ae-weight/<str:ae>/
and
api/ae-weight/<str:ae>/<str:target>/


To mimic the behaviour of 
api/weight/<str:target>/
and
api/weight/<str:target>/<str:ae>/

except it searches by adverse event and returns a list of targets