### PR TITLE
quick fix for the new date format in opentargets data

### DIFF
--- a/backend/datasets/get_datasets.py
+++ b/backend/datasets/get_datasets.py
@@ -209,8 +209,11 @@ def get_open_targets_version_from_file(file_name):
                 data_version = line.split('=')[1].strip()
                 if data_version.startswith('"') and data_version.endswith('"'):
                     data_version = data_version[1:-1]
+                # If data_version is in year.month format, append the first day of the month
+                if data_version.count('.') == 1:
+                    data_version += ".01"
                 break
-        
+        print(f"Data version: {data_version}")
         # Print the data_version value
         if data_version:
             return datetime.strptime(data_version, '%y.%m.%d').date()
@@ -218,6 +221,7 @@ def get_open_targets_version_from_file(file_name):
             return datetime.strptime('21.01.01', '%y.%m.%d').date()
     except Exception as e:
         return datetime.strptime('21.01.01', '%y.%m.%d').date()
+
 
 
 

--- a/neo4j/Dockerfile
+++ b/neo4j/Dockerfile
@@ -14,7 +14,7 @@ ENV NEO4J_AUTH=neo4j/gradvek1 \
 # COPY data /data
 # COPY logs /logs
 # COPY import /var/lib/neo4j/import
-COPY plugins /plugins
+# COPY plugins /plugins
 
 # Expose Neo4j ports
 EXPOSE 7474 7473 7687

--- a/neo4j/Dockerfile
+++ b/neo4j/Dockerfile
@@ -1,4 +1,4 @@
-FROM neo4j
+FROM neo4j:5.9.0
 
 # Set environment variables
 ENV NEO4J_AUTH=neo4j/gradvek1 \


### PR DESCRIPTION
In June OpenTargets removed the 'day' value in the date field we use to determine the version of a data set. This caused some incorrect labeling when the application updated it data.

This change makes it so if the 'day' field will default to the first when that value is missing.

Also changed Neo4j version from 'latest' to '5.9.0', both GDS and APOC are updated to use it. This should avoid accidental breaking version changes.